### PR TITLE
Harden Docker verification flow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.env
+.env.*
+.git
+.github
+node_modules
+vendor
+storage/logs
+storage/framework/cache
+storage/framework/sessions
+storage/framework/testing
+storage/framework/views
+npm-debug.log
+yarn-error.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,25 @@
 FROM php:8.2
 
 # Update package lists and install required dependencies
-RUN apt-get update -y && apt-get install -y openssl zip unzip libonig-dev
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        cmake \
+        git \
+        libcurl4-openssl-dev \
+        libonig-dev \
+        libxml2-dev \
+        openssl \
+        unzip \
+        zip \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Composer globally
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-# Install PHP extensions required by Laravel
-RUN docker-php-ext-install pdo mbstring
+# Install PHP extensions required by Laravel and Couchbase SDK usage
+RUN docker-php-ext-install dom mbstring pdo \
+    && printf "\n" | pecl install couchbase \
+    && docker-php-ext-enable couchbase
 
 # Set the working directory to /app
 WORKDIR /app
@@ -17,7 +29,7 @@ WORKDIR /app
 COPY . /app
 
 # Install project dependencies using Composer
-RUN composer install
+RUN composer install --no-interaction --prefer-dist --optimize-autoloader     && mkdir -p storage/framework/cache storage/framework/sessions storage/framework/testing storage/framework/views storage/logs bootstrap/cache
 
 # Set the default command to run when the container starts
 CMD php artisan serve --host=0.0.0.0 --port=8000

--- a/README.md
+++ b/README.md
@@ -72,9 +72,7 @@ Specifically, you need to do the following:
 - Create the [database credentials](https://docs.couchbase.com/cloud/clusters/manage-database-users.html) to access the travel-sample bucket (Read and Write) used in the application.
 - [Allow access](https://docs.couchbase.com/cloud/clusters/allow-ip-address.html) to the Cluster from the IP on which the application is running.
 
-All configuration for communication with the database is read from the environment variables. We have provided a convenience feature in this quickstart to read the environment variables from a local file, `config/couchbase.php`.
-
-> Note: Set the values for the Couchbase connection in the `config/couchbase.php` file. This file is used to store sensitive information and should not be checked into version control.
+All configuration for communication with the database is read from environment variables. The checked-in `config/couchbase.php` file already maps those environment variables into the Laravel app, so you only need to set the values in your local `.env` file (or pass them in as container environment variables).
 
 ```php
 <?php
@@ -84,6 +82,15 @@ return [
     'password' => env('DB_PASSWORD', 'password'),
     'bucket' => env('DB_BUCKET', 'travel-sample'),
 ];
+```
+
+Add the corresponding values to `.env`:
+
+```dotenv
+DB_CONN_STR=couchbases://cb.<your-cluster>.<your-id>.cloud.couchbase.com
+DB_USERNAME=<your-username>
+DB_PASSWORD=<your-password>
+DB_BUCKET=travel-sample
 ```
 
 > Note: The connection string expects the `couchbases://` or `couchbase://` part.
@@ -109,10 +116,10 @@ docker build -t couchbase-laravel-quickstart .
 - Run the Docker image
 
 ```sh
-docker run -p 8000:8000 couchbase-laravel-quickstart
+docker run --rm -p 8000:8000 --env-file .env couchbase-laravel-quickstart
 ```
 
-> Note: The `config/couchbase.php` file has the connection information to connect to your Capella cluster. These will be part of the environment variables in the Docker container.
+> Note: If the Couchbase cluster is running on the same machine as Docker, use a host-reachable connection string in `.env` (for example `couchbase://host.docker.internal`, or `--network host` on Linux) so the container can reach the cluster.
 
 ### Verifying the Application
 
@@ -218,7 +225,7 @@ class HotelIntegrationTest extends TestCase
 
 If you are running this quickstart with a self-managed Couchbase cluster, you need to [load](https://docs.couchbase.com/server/current/manage/manage-settings/install-sample-buckets.html) the travel-sample data bucket in your cluster and generate the credentials for the bucket.
 
-You need to update the connection string and the credentials in the `config/couchbase.php` file:
+You need to update the connection string and credentials in your local `.env` file:
 
 ```php
 <?php

--- a/app/Providers/CouchbaseServiceProvider.php
+++ b/app/Providers/CouchbaseServiceProvider.php
@@ -24,7 +24,8 @@ class CouchbaseServiceProvider extends ServiceProvider
         'view:clear',
         'route:cache',
         'route:clear',
-        'package:discover'
+        'package:discover',
+        'vendor:publish'
     ];
 
     private function shouldSkipDatabaseOperations(): bool

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^8.2",
         "couchbase/couchbase": "^4.2",
-        "darkaonline/l5-swagger": "^9.0",
+        "darkaonline/l5-swagger": "^10.1",
         "laravel/framework": "^12.1",
         "laravel/tinker": "^2.9"
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "devDependencies": {
         "axios": "^1.6.4",
-        "laravel-vite-plugin": "^1.0",
-        "vite": "^6.0"
+        "laravel-vite-plugin": "^2.1",
+        "vite": "^7.3"
     }
 }

--- a/tests/Feature/HotelTest.php
+++ b/tests/Feature/HotelTest.php
@@ -84,6 +84,9 @@ class HotelTest extends TestCase
         // Assert
         $response->assertStatus(200);
         $this->assertNotEmpty($response->json());
+        $response->assertJsonStructure([
+            '*' => ['country', 'city'],
+        ]);
 
         foreach ($response->json() as $hotel) {
             $this->assertSame('United States', $hotel['country']);

--- a/tests/Feature/HotelTest.php
+++ b/tests/Feature/HotelTest.php
@@ -83,8 +83,12 @@ class HotelTest extends TestCase
 
         // Assert
         $response->assertStatus(200);
+        $this->assertNotEmpty($response->json());
 
-        $response->assertJsonFragment(['name' => 'Four Seasons Hotel']);
+        foreach ($response->json() as $hotel) {
+            $this->assertSame('United States', $hotel['country']);
+            $this->assertSame('San Francisco', $hotel['city']);
+        }
     }
 
     /** @test */


### PR DESCRIPTION
## Summary
- harden the Docker image so it installs the Couchbase PHP extension, skips DB-bound artisan work during image build, and creates the Laravel cache/view/log directories needed for a working containerized app
- add a `.dockerignore` and update the README so local/Docker setup uses `.env` instead of treating the checked-in `config/couchbase.php` file as secret config
- make the hotel filter test assert the requested exact attributes instead of relying on a stale `travel-sample` hotel name
- fold in the currently-open direct dependency bumps that were low-risk to carry with this branch:
  - `actions/checkout`: `v4` -> `v6`
  - `laravel-vite-plugin`: `^1.0` -> `^2.1`
  - `vite`: `^6.0` -> `^7.3`
  - `darkaonline/l5-swagger`: `^9.0` -> `^10.1`

## Verification
- `docker build -t php-laravel-quickstart:dex-2026-05-26 .`
- `docker run --rm php-laravel-quickstart:dex-2026-05-26 composer audit --no-interaction` *(no security advisories; reports 3 existing abandoned packages)*
- `docker run --rm --network host -v "$PWD/.env:/app/.env" php-laravel-quickstart:dex-2026-05-26 php artisan key:generate --force`
- `docker run --rm --network host -v "$PWD/.env:/app/.env" php-laravel-quickstart:dex-2026-05-26 php artisan test`
- `docker run --rm --network host -v "$PWD/.env:/app/.env" php-laravel-quickstart:dex-2026-05-26 php artisan serve --host=127.0.0.1 --port=8001`
- HTTP walkthroughs:
  - `GET /`
  - `GET /api/v1/hotels/autocomplete?name=Hotel`
  - `GET /api/v1/hotels/filter?country=United+States&city=San+Francisco`
- dependency follow-up on this branch:
  - `npm install --no-package-lock`
  - `npm run build`
  - `composer update --dry-run --no-scripts --no-interaction` *(resolver reaches `ext-dom` platform check on this host; see notes)*

## Evidence
- `tutorial-maintenance/runs/php-laravel-quickstart/2026-05-26T19-33-00Z/verification.md`

## Notes
- This run installed the local `travel-sample` bucket before verification so the quickstart could be exercised end to end.
- The local cluster's Search service was still unavailable to the SDK during verification, so hotel search/filter exercised the app's N1QL fallback path.
- The npm follow-up resolved `axios@1.16.1`, `laravel-vite-plugin@2.1.0`, and `vite@7.3.3` without needing a lockfile change.
- Local host-side Composer verification still stops at a missing CLI `ext-dom` platform requirement, so the composer-side dependency follow-up is relying on the PR's GitHub Actions run for the clean end-to-end install/test signal.

## Media evidence
- Captured the live Swagger UI at `/api/documentation` from the verified Dockerized app.
- Shows that the image now boots cleanly and exposes the API docs surface reviewers would expect from the quickstart.

![Laravel Swagger UI served from the hardened Dockerized app](https://res.cloudinary.com/dhwqj0ps2/image/upload/v1779827885/pr-evidence/couchbase-examples/php-laravel-quickstart/pr-36/swagger-ui.png)

<details><summary>Notes</summary>

- Local artifact path: `tutorial-maintenance/runs/php-laravel-quickstart/2026-05-26T19-33-00Z/swagger-ui.png`

</details>
- Short walkthrough video of `/api/documentation` from the verified Dockerized Laravel app.
[Short walkthrough video of the Laravel Swagger UI](https://res.cloudinary.com/dhwqj0ps2/video/upload/v1779836916/pr-evidence/couchbase-examples/php-laravel-quickstart/pr-36/swagger-ui-walkthrough.webm)

<details><summary>Notes</summary>

- Local artifact path: `tutorial-maintenance/runs/php-laravel-quickstart/2026-05-26T19-33-00Z/swagger-ui.webm`

</details>
