### PR TITLE
Update Vite toolchain dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
         "build": "vite build"
     },
     "devDependencies": {
-        "axios": "^1.6.4",
-        "laravel-vite-plugin": "^2.1",
-        "vite": "^7.3"
+        "axios": "^1.18.1",
+        "laravel-vite-plugin": "^3.1.0",
+        "vite": "^8.1.0"
     }
 }


### PR DESCRIPTION
## Summary
- update the repo's JS toolchain surface to `axios@^1.18.1`, `laravel-vite-plugin@^3.1.0`, and `vite@^8.1.0`
- keep the PHP/Laravel app code unchanged and reverify the existing Dockerized Laravel test flow plus a live docs/API smoke check

## Verification
- `docker build -t php-laravel-quickstart-sweep-20260630 .`
- `docker run --rm --env-file .env -v "$PWD/.env:/app/.env:ro" php-laravel-quickstart-sweep-20260630 php artisan test`
- `npm install --package-lock=false`
- `npm run build`
- `docker run --name php-laravel-sweep-live --rm -p 18000:8000 --env-file .env -v "$PWD/.env:/app/.env:ro" php-laravel-quickstart-sweep-20260630`
- `curl -I http://127.0.0.1:18000/api/documentation`
- `curl http://127.0.0.1:18000/api/v1/airlines/list`

## Evidence
- `php artisan test` passed in Docker with `47 passed (422 assertions)`
- `npm run build` passed on the refreshed Vite 8 toolchain
- Live smoke check returned `HTTP/1.1 200 OK` for `/api/documentation` and a valid JSON payload from `/api/v1/airlines/list`
- Verification notes: `tutorial-maintenance/runs/php-laravel-quickstart/2026-06-30T1455Z/verification.md`
- Test log: `tutorial-maintenance/runs/php-laravel-quickstart/2026-06-30T1455Z/artisan-test-fixed.log`
- Live docs/API smoke logs: `tutorial-maintenance/runs/php-laravel-quickstart/2026-06-30T1455Z/curl-docs-head.txt`, `tutorial-maintenance/runs/php-laravel-quickstart/2026-06-30T1455Z/curl-airlines-list.json`

## Notes
- The initial container test failure was caused by `/app/.env` being absent; materializing `.env` from `.env.example` plus machine-level credentials and mounting it into the container fixed the repo-local execution path.
- `npm audit` still reports the current transitive `form-data` advisory after the `axios` bump, so this PR does not claim a clean JS audit.
- I did not add reviewer media on this pass; the verification artifacts above capture the docs/API smoke check and full test run.
